### PR TITLE
Fix a minor typo

### DIFF
--- a/modules/5-how-to-write-search-queries.md
+++ b/modules/5-how-to-write-search-queries.md
@@ -55,7 +55,7 @@ The conversation ID is the Tweet ID of the main Tweet for which you want all the
 
 When you use the recent search and full-archive endpoints as part of the Academic Research product track, your query length can be up to 1024 characters. In the Standard product track, you have access to the recent search endpoint and your query length can be up to 512 characters.
 
-When you use the filtered stream endpoint as part of the Academic Research product track , you can set up to 1000 concurrent rules and each rule can be 1024 characters long.n the Standard product track, you can set 25 concurrent rules and each rule is 512 characters long.
+When you use the filtered stream endpoint as part of the Academic Research product track , you can set up to 1000 concurrent rules and each rule can be 1024 characters long. In the Standard product track, you can set 25 concurrent rules and each rule is 512 characters long.
 
 See the complete list of operators supported by endpoints:
 


### PR DESCRIPTION
The 2nd line of 2nd paragraph under the section "Operator availability and query length" contained a typo. (".n the Standard product track..." instead of "In the Standard product track...").

### Problem

Explain the context and why you're making that change.  What is the
problem you're trying to solve? In some cases there is not a problem
and this can be thought of being the motivation for your change.

### Solution

Describe the modifications you've done.

### Result

What will change as a result of your pull request? Note that sometimes
this section is unnecessary because it is self-explanatory based on
the solution.
