### PR TITLE
Update 6c-labs-code-academic-r.md

### DIFF
--- a/modules/6c-labs-code-academic-r.md
+++ b/modules/6c-labs-code-academic-r.md
@@ -15,7 +15,7 @@ Also, make sure you have your bearer token from an app connected to your academi
 In order to install the academicTwitteR package, in your terminal, run the following:
 
 ```bash
-install.packages("academicTwitteR")
+install.packages("academictwitteR")
 ```
 
 ## Importing the academicTwitteR package


### PR DESCRIPTION
### Problem

Getting a `Warning in install.packages :
  package ‘academicTwitteR’ is not available for this version of R` error when trying to install the package. 

### Solution

Fixing the case of `TwitteR` to `twitteR` solved the issue.

### Result

Edit to README.md